### PR TITLE
[#6906] Update Faraday gem version

### DIFF
--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   end
   s.require_paths = ['lib']
 
-  s.add_dependency 'faraday', '~> 0.8'
+  s.add_dependency 'faraday', '1.0.1'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 


### PR DESCRIPTION
To update `elasticsearch` gem to 7.9.0 in `shiphawk-dev` we need to update `faraday`, because `elasticsearch-transport (= 7.9.0)` depends on `faraday (~> 1)`. Thus we need to update `faraday` here as well.