### PR TITLE
[#infrastructure] Update faraday gem dependancy

### DIFF
--- a/zipkin-tracer.gemspec
+++ b/zipkin-tracer.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   end
   s.require_paths = ['lib']
 
-  s.add_dependency 'faraday', '1.0.1'
+  s.add_dependency 'faraday', '~> 1.0'
   s.add_dependency 'rack', '>= 1.0'
   s.add_dependency 'sucker_punch', '~> 2.0'
 


### PR DESCRIPTION
We need to unlock the faraday version.

In prev version of gem - it was unlocked, not sure why we lock it in the next PR

https://github.com/ShipHawk/zipkin-ruby/pull/2

cc @vasiliysablin @MorganFujimaka 